### PR TITLE
Default company name should come from Spree::Store

### DIFF
--- a/app/models/spree/stock/estimator_decorator.rb
+++ b/app/models/spree/stock/estimator_decorator.rb
@@ -52,7 +52,7 @@ Spree::Stock::Estimator.class_eval do
     ep_address_attrs[:company] = if address.respond_to?(:company)
       address.company
     else
-      Spree::Config[:site_name]
+      Spree::Store.current.name
     end
     ep_address_attrs[:name] = address.full_name if address.respond_to?(:full_name)
     ep_address_attrs[:street1] = address.address1


### PR DESCRIPTION
Spree::Config[:site_name] was deprecated in Spree 2.3.
