### PR TITLE
Address Validation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 # Provides basic authentication functionality for testing parts of your engine
-gem 'spree', github: 'spree/spree'
-gem 'spree_auth_devise', github: 'spree/spree_auth_devise'
+gem 'spree', github: 'spree/spree', branch: '2-4-stable'
+gem 'spree_auth_devise', github: 'spree/spree_auth_devise', branch: '2-4-stable'
 
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -2,20 +2,14 @@ require 'bundler'
 Bundler::GemHelper.install_tasks
 
 require 'rspec/core/rake_task'
-require 'spree/testing_support/extension_rake'
+require 'spree/testing_support/common_rake'
 
 RSpec::Core::RakeTask.new
 
-task :default do
-  if Dir["spec/dummy"].empty?
-    Rake::Task[:test_app].invoke
-    Dir.chdir("../../")
-  end
-  Rake::Task[:spec].invoke
-end
+task :default => [:spec]
 
 desc 'Generates a dummy app for testing'
 task :test_app do
   ENV['LIB_NAME'] = 'spree_easypost'
-  Rake::Task['extension:test_app'].invoke
+  Rake::Task['common:test_app'].invoke
 end

--- a/app/models/spree/address_decorator.rb
+++ b/app/models/spree/address_decorator.rb
@@ -13,6 +13,12 @@ protected
 
     if response.message.present?
       errors.add(:base, response.message)
+    else
+      self.address1 = response.street1
+      self.address2 = response.street2
+      self.city = response.city
+      self.state = Spree::State.find_by_abbr(response.state) unless state.try(:abbr) == response.state
+      self.zipcode = response.zip
     end
 
   rescue EasyPost::Error => e

--- a/app/models/spree/address_decorator.rb
+++ b/app/models/spree/address_decorator.rb
@@ -9,7 +9,12 @@ module Spree::AddressDecorator
 
 protected
   def validate_address
-    EasyPost::Address.create_and_verify(easy_post_attributes)
+    response = EasyPost::Address.create_and_verify(easy_post_attributes)
+
+    if response.message.present?
+      errors.add(:base, response.message)
+    end
+
   rescue EasyPost::Error => e
     errors.add(:base, e.message)
   end

--- a/app/models/spree/address_decorator.rb
+++ b/app/models/spree/address_decorator.rb
@@ -1,0 +1,31 @@
+module Spree::AddressDecorator
+  def self.prepended(klass)
+    klass.validate :validate_address, if: :usa?
+  end
+
+  def usa?
+    country.try(:iso) == 'US'
+  end
+
+protected
+  def validate_address
+    EasyPost::Address.create_and_verify(easy_post_attributes)
+  rescue EasyPost::Error => e
+    errors.add(:base, e.message)
+  end
+
+  def easy_post_attributes
+    {
+      name: full_name,
+      street1: address1,
+      street2: address2,
+      city: city,
+      state: state.try(:abbr) || state_name,
+      zip: zipcode,
+      country: country.try(:iso),
+      phone: phone
+    }
+  end
+end
+
+Spree::Address.prepend(Spree::AddressDecorator)

--- a/app/models/spree/address_decorator.rb
+++ b/app/models/spree/address_decorator.rb
@@ -9,33 +9,7 @@ module Spree::AddressDecorator
 
 protected
   def validate_address
-    response = EasyPost::Address.create_and_verify(easy_post_attributes)
-
-    if response.message.present?
-      errors.add(:base, response.message)
-    else
-      self.address1 = response.street1
-      self.address2 = response.street2
-      self.city = response.city
-      self.state = Spree::State.find_by_abbr(response.state) unless state.try(:abbr) == response.state
-      self.zipcode = response.zip
-    end
-
-  rescue EasyPost::Error => e
-    errors.add(:base, e.message)
-  end
-
-  def easy_post_attributes
-    {
-      name: full_name,
-      street1: address1,
-      street2: address2,
-      city: city,
-      state: state.try(:abbr) || state_name,
-      zip: zipcode,
-      country: country.try(:iso),
-      phone: phone
-    }
+    Spree::EasyPost::AddressVerification.new(self).verify!
   end
 end
 

--- a/app/models/spree/easy_post/address_verification.rb
+++ b/app/models/spree/easy_post/address_verification.rb
@@ -1,0 +1,46 @@
+class Spree::EasyPost::AddressVerification
+  def initialize(address)
+    @address = address
+  end
+
+  def verify!
+    response = verify
+
+    parse(response)
+  rescue EasyPost::Error => e
+    add_error(e.message)
+  end
+
+  def attributes
+    {
+      name:    @address.full_name,
+      street1: @address.address1,
+      street2: @address.address2,
+      city:    @address.city,
+      state:   @address.state.try(:abbr) || @address.state_name,
+      zip:     @address.zipcode,
+      country: @address.country.try(:iso),
+      phone:   @address.phone
+    }
+  end
+
+  def verify
+    EasyPost::Address.create_and_verify(attributes)
+  end
+
+  def parse(response)
+    if response.message.present?
+      add_error(response.message)
+    else
+      @address.address1 = response.street1
+      @address.address2 = response.street2
+      @address.city     = response.city
+      @address.state    = Spree::State.find_by_abbr(response.state)
+      @address.zipcode  = response.zip
+    end
+  end
+
+  def add_error(message)
+    @address.errors.add(:base, message)
+  end
+end

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -28,5 +28,27 @@ describe Spree::Address do
       expect(address).to be_invalid
       expect(address.errors[:base]).to eq(['Whooops'])
     end
+
+    it "uses what comes back from easy_post" do
+      create(:state, abbr: "NY")
+
+      response = stub(
+        message: nil,
+        street1: "street1 updated",
+        street2: "street2 updated",
+        city: "city updated",
+        state: "NY",
+        zip: "zip updated"
+      )
+      expect(EasyPost::Address).to receive(:create_and_verify).and_return(response)
+      address = build(:address, country: usa )
+
+      expect(address).to be_valid
+      expect(address.address1).to eq("street1 updated")
+      expect(address.address2).to eq("street2 updated")
+      expect(address.city).to eq("city updated")
+      expect(address.state.abbr).to eq("NY")
+      expect(address.zipcode).to eq("zip updated")
+    end
   end
 end

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -19,5 +19,14 @@ describe Spree::Address do
       expect(address).to be_invalid
       expect(address.errors[:base]).to eq(['Address Not Found'])
     end
+
+    it "considers invalid, when message returned" do
+      response = stub(message: "Whooops")
+      expect(EasyPost::Address).to receive(:create_and_verify).and_return(response)
+      address = build(:address, country: usa )
+
+      expect(address).to be_invalid
+      expect(address.errors[:base]).to eq(['Whooops'])
+    end
   end
 end

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -4,7 +4,20 @@ describe Spree::Address do
   it "doesn't validate non-USA address" do
     expect(EasyPost::Address).to_not receive(:create_and_verify)
 
-    address = build(:address, country: Spree::Country.find_by_iso('CA') )
+    canada = create(:country, iso: 'CA')
+    address = build(:address, country: canada)
     address.save
+  end
+
+  context "validating USA address" do
+    let(:usa) { create(:country, iso: 'US') }
+
+    it "considers invalid, when not found" do
+      expect(EasyPost::Address).to receive(:create_and_verify).and_raise(EasyPost::Error.new("Address Not Found", 400))
+      address = build(:address, country: usa )
+
+      expect(address).to be_invalid
+      expect(address.errors[:base]).to eq(['Address Not Found'])
+    end
   end
 end

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -21,7 +21,7 @@ describe Spree::Address do
     end
 
     it "considers invalid, when message returned" do
-      response = stub(message: "Whooops")
+      response = double(message: "Whooops")
       expect(EasyPost::Address).to receive(:create_and_verify).and_return(response)
       address = build(:address, country: usa )
 
@@ -32,7 +32,7 @@ describe Spree::Address do
     it "uses what comes back from easy_post" do
       create(:state, abbr: "NY")
 
-      response = stub(
+      response = double(
         message: nil,
         street1: "street1 updated",
         street2: "street2 updated",

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+describe Spree::Address do
+  it "doesn't validate non-USA address" do
+    expect(EasyPost::Address).to_not receive(:create_and_verify)
+
+    address = build(:address, country: Spree::Country.find_by_iso('CA') )
+    address.save
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -79,4 +79,6 @@ RSpec.configure do |config|
   end
 
   config.fail_fast = ENV['FAIL_FAST'] || false
+
+  config.infer_spec_type_from_file_location!
 end

--- a/spree_easypost.gemspec
+++ b/spree_easypost.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.requirements << 'none'
 
   s.add_dependency 'spree_core', '~> 2.4'
-  s.add_dependency 'easypost', '2.0.11'
+  s.add_dependency 'easypost', '2.1.0'
 
   s.add_development_dependency 'spree_sample'
   s.add_development_dependency 'capybara', '~> 2.1'

--- a/spree_easypost.gemspec
+++ b/spree_easypost.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'spree_core', '~> 2.4'
   s.add_dependency 'easypost', '2.0.11'
 
+  s.add_development_dependency 'spree_sample'
   s.add_development_dependency 'capybara', '~> 2.1'
   s.add_development_dependency 'coffee-rails'
   s.add_development_dependency 'database_cleaner'

--- a/spree_easypost.gemspec
+++ b/spree_easypost.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.add_dependency 'spree_core', '~> 2.4.7.beta'
+  s.add_dependency 'spree_core', '~> 2.4'
   s.add_dependency 'easypost', '2.0.11'
 
   s.add_development_dependency 'capybara', '~> 2.1'

--- a/spree_easypost.gemspec
+++ b/spree_easypost.gemspec
@@ -11,8 +11,8 @@ Gem::Specification.new do |s|
   # s.email     = 'you@example.com'
   s.homepage    = 'http://www.godynamo.com'
 
-  #s.files       = `git ls-files`.split("\n")
-  #s.test_files  = `git ls-files -- {test,spec,features}/*`.split("\n")
+  s.files       = `git ls-files`.split("\n")
+  s.test_files  = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.require_path = 'lib'
   s.requirements << 'none'
 


### PR DESCRIPTION
This PR adds support for Easy Post Address Validation

Every time a USA address is validated it sent to easy post for verification. It handles the following situations:
- Address is invalid: a validation message is added to the address record
- Address is valid but missing data (eg apartment #): a validation message is added to the address record
- Address is valid: the address data is updated with the data returned from easy post (e.g. the zipcode will be expanded or the city name's spelling might be corrected, etc)
